### PR TITLE
Remove special handling of html suffix fallback

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -60,12 +60,6 @@ http {
     <% end %>
     }
 
-  <% if clean_urls %>
-    location ~ \.html$ {
-      try_files $uri =404;
-    }
-  <% end %>
-
   <% if https_only %>
     if ($http_x_forwarded_proto != "https") {
       return 301 https://$host$request_uri;


### PR DESCRIPTION
# Why

We have some pre-existing urls like `/amazon-marketplace-outlook.html` that I need to 301 redirect to `/insite` for SEO reasons as we move to the new site.

The way this buildpack is written, it seems that if a url ends with `.html` and 'clean urls' are enabled, it will not attempt to use any other url resolution approaches: either there is an html file by that name or it immediately 404s. I don't see the point of that and it's making it impossible to add redirects for .html urls.